### PR TITLE
Instead of wiping out the whole page, just replace the swagger import

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
 
       // Replace if tag is found
       if (definition !== null) {
-        page.content = swaggers[definition[1]];
+         page.content = page.content.replace(regex, swaggers[definition[1]]);
       }
       return page;
     },


### PR DESCRIPTION
I'd like to be able to keep my existing page, including things like the page title and header text, and import the swagger data below that. We could make this a preference if people prefer the option to blow away the entire page.